### PR TITLE
Add support for when called from a Scheduled Job

### DIFF
--- a/hebrewcalendarhelper.php
+++ b/hebrewcalendarhelper.php
@@ -168,6 +168,15 @@ function hebrewcalendarhelper_civicrm_tokens( &$tokens ){
  
 function hebrewcalendarhelper_civicrm_tokenValues( &$values, &$contactIDs, $job = null, $tokens = array(), $context = null) {
 	
+  // When running from Scheduled Jobs, we only receive a single contactId,
+  // not an array. CiviCRM also expects us to return a flat array.
+  $is_scheduled_job = FALSE;
+
+  if (!is_array($contactIDs)) {
+    $contactIDs = [$contactIDs];
+    $is_scheduled_job = TRUE;
+  }
+
 	if(!empty($tokens['hebrewcalendar'])){
 		require_once 'utils/HebrewCalendar.php';
 		$hebrew_format = 'dd MM yy';
@@ -300,7 +309,13 @@ function hebrewcalendarhelper_civicrm_tokenValues( &$values, &$contactIDs, $job 
 				$token_date_portion,
 				$token_yah_hebrew_date_hebrew) ;
 		
-
+    if ($is_scheduled_job) {
+      foreach ($contactIDs as $cid) {
+        foreach ($values[$cid] as $key => $val) {
+          $values[$key] = $val;
+        }
+      }
+    }
 	}
 	 
 }

--- a/utils/HebrewCalendar.php
+++ b/utils/HebrewCalendar.php
@@ -3320,6 +3320,10 @@ class HebrewCalendar{
 
 						$default_seperator = ", ";
 
+            if (!isset($values[$cid])) {
+              $values[$cid] = [];
+            }
+
 						if(array_key_exists($cid,  $values)){
 							// print "<br>Fill in token values.";
 							if( isset( $tmp_deceasedids_for_con[$cid] )){


### PR DESCRIPTION
When running from Scheduled Jobs, the token code only receive a single contactId, not an array. CiviCRM also expects us to return a flat array. Tested on CiviCRM >= 5.10.

To be honest, I'm not sure how well this behaviour is documented in CiviCRM, and it feels like a core bug, I will understand if you prefer not to merge. :-)